### PR TITLE
.nl responds with "is free"

### DIFF
--- a/src/availability-checks.json
+++ b/src/availability-checks.json
@@ -91,7 +91,7 @@
     "whois.nc": "No entries found",
     "whois.verisign-grs.com": "No match",
     "whois.nic.net.ng": "Domain Status: Available",
-    "whois.domain-registry.nl": "Domain Status: Available",
+    "whois.domain-registry.nl": "is free",
     "whois.norid.no": "No match",
     "whois.nic.nu": "NO MATCH",
     "whois.srs.net.nz": "Available",


### PR DESCRIPTION
A typical response of the .nl whois server looks like this..

``` txt
example987.nl is free\r\n
```
